### PR TITLE
Fix: DrainpipeMonitoringService 내 오타 수정

### DIFF
--- a/src/drainpipe-monitoring/drainpipe-monitoring.controller.ts
+++ b/src/drainpipe-monitoring/drainpipe-monitoring.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get } from '@nestjs/common';
 import { DrainpipeMonitoringService } from './drainpipe-monitoring.service';
 import { RequestDrainpipeInfoDto } from './dto/request.drainpipe-info.dto';
-import { ResponseDrainpipeInfoDto } from './response.drainpipe-info.dto';
+import { ResponseDrainpipeInfoDto } from './dto/response.drainpipe-info.dto';
 
 @Controller('drainpipe-monitoring')
 export class DrainpipeMonitoringController {

--- a/src/drainpipe-monitoring/drainpipe-monitoring.service.ts
+++ b/src/drainpipe-monitoring/drainpipe-monitoring.service.ts
@@ -2,10 +2,8 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { firstValueFrom, map } from 'rxjs';
-import { ResponseDrainpipeInfoDto } from './response.drainpipe-info.dto';
+import { ResponseDrainpipeInfoDto } from './dto/response.drainpipe-info.dto';
 import { DrainpipeInfoOpenApiDto } from './dto/drainpipe-info-openapi.dto';
-import { start } from 'repl';
-import { Any } from 'typeorm';
 
 @Injectable()
 export class DrainpipeMonitoringService {
@@ -14,24 +12,20 @@ export class DrainpipeMonitoringService {
     private readonly configService: ConfigService,
   ) {}
 
-  //행 전체 개수 구하기
-  async getDataTotalCount(reqGubn, reqYmd, reqYmd2) {
-    const data = await this.getApiData(1, 1, reqGubn, reqYmd, reqYmd2);
-    return data.DrainpipeMonitoringInfo.list_total_count;
-  }
-
   async getDrainpipeApi(
     reqGubn,
     reqYmd,
     reqYmd2,
   ): Promise<ResponseDrainpipeInfoDto[]> {
     //데이터 총 개수
-    const totalDataCount = await this.getDataTotalCount(
+    const totalDataCount = await this.getApiData(
+      'count',
+      1,
+      1,
       reqGubn,
       reqYmd,
       reqYmd2,
     );
-
     //리턴할 새 배열 생성
     const responseArr = [];
 
@@ -54,7 +48,7 @@ export class DrainpipeMonitoringService {
     }
 
     //1000개 단위로 나눈 나머지 요청
-    if (totalDataCount < repeat * 1000) {
+    if (totalDataCount > repeat * 1000) {
       const getData = await this.rowData(
         repeat * 1000 + 1,
         totalDataCount,
@@ -67,20 +61,31 @@ export class DrainpipeMonitoringService {
         responseArr.push(getData[idx]);
       }
     }
-
     return responseArr;
   }
 
   //각 행 가져오기
   async rowData(startIdx, lastIdx, reqGubn, reqYmd, reqYmd2) {
-    const data = await (
-      await this.getApiData(startIdx, lastIdx, reqGubn, reqYmd, reqYmd2)
-    ).DrainpipeMonitoringInfo.row;
+    const data = await this.getApiData(
+      'row',
+      startIdx,
+      lastIdx,
+      reqGubn,
+      reqYmd,
+      reqYmd2,
+    );
     return data;
   }
 
   //OPEN API 데이터 가져오기
-  async getApiData(startIdx, lastIdx, reqGubn, reqYmd, reqYmd2) {
+  async getApiData(
+    tag,
+    startIdx,
+    lastIdx,
+    reqGubn,
+    reqYmd,
+    reqYmd2,
+  ): Promise<any> {
     const key = this.configService.get<string>('OPEN_API_KEY');
     //const testUrl = `http://openapi.seoul.go.kr:8088/${key}/json/DrainpipeMonitoringInfo/1/5/01/2022030214/2022030315`;
     const url = `http://openapi.seoul.go.kr:8088/${key}/json/DrainpipeMonitoringInfo/${startIdx}/${lastIdx}/${reqGubn}/${reqYmd}/${reqYmd2}`;
@@ -90,6 +95,11 @@ export class DrainpipeMonitoringService {
         .get<DrainpipeInfoOpenApiDto>(url)
         .pipe(map((response) => response.data)),
     );
-    return responseData;
+
+    if (tag === 'row') {
+      return responseData.DrainpipeMonitoringInfo.row;
+    } else if (tag === 'count') {
+      return responseData.DrainpipeMonitoringInfo.list_total_count;
+    }
   }
 }

--- a/src/drainpipe-monitoring/dto/drainpipe-info-openapi.dto.ts
+++ b/src/drainpipe-monitoring/dto/drainpipe-info-openapi.dto.ts
@@ -1,4 +1,4 @@
-import { ResponseDrainpipeInfoDto } from '../response.drainpipe-info.dto';
+import { ResponseDrainpipeInfoDto } from '../dto/response.drainpipe-info.dto';
 
 export class DrainpipeInfoOpenApiDto {
   DrainpipeMonitoringInfo: {


### PR DESCRIPTION
 DrainpipeMonitoringService 클래스 파일 51번째 줄에 부등호 오타 변경

getDataTotalCount() 삭제

Promise.all()을 사용하려고 했으나 실패